### PR TITLE
fix(controller): 表单 action 写死导致不能提交

### DIFF
--- a/src/Http/Controllers/Admin/OfficialAccount/MenuController.php
+++ b/src/Http/Controllers/Admin/OfficialAccount/MenuController.php
@@ -29,7 +29,7 @@ class MenuController extends BaseController
 
         $form = new Form(new WechatConfig());
 
-        $form->setAction('/admin/wechat/official-account/menu');
+        $form->setAction('menu');
 
         $form->wechatMenu('menu', $config->name)->default(isset($menu['selfmenu_info']) ? $menu['selfmenu_info'] : null);
         $form->hidden('app_id')->default($config->app_id);


### PR DESCRIPTION
控制器中由于写死 了action 的路径，会导致 Admin 路由前缀不是 `admin` 的情况下，接口报 404 错误。